### PR TITLE
PE-8905: leaves-first push in WriteSignedEntity to heal dangling index children

### DIFF
--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -52,7 +52,7 @@ func WriteSignedEntity(dst name.Reference, si oci.SignedEntity, opts ...Option) 
 		}
 	case oci.SignedImageIndex:
 		fmt.Println("writing signed image index to", dst.Name())
-		if err := goremote.WriteIndex(dst, si, o.ROpt...); err != nil {
+		if err := writeIndexLeavesFirst(dst, si, o.ROpt...); err != nil {
 			return fmt.Errorf("writing index: %w", err)
 		}
 	default:
@@ -72,6 +72,36 @@ func WriteSignedEntity(dst name.Reference, si oci.SignedEntity, opts ...Option) 
 	}
 
 	return nil
+}
+
+// writeIndexLeavesFirst pushes each child of ii by digest before publishing the index.
+func writeIndexLeavesFirst(dst name.Reference, ii v1.ImageIndex, opts ...goremote.Option) error {
+	im, err := ii.IndexManifest()
+	if err != nil {
+		return fmt.Errorf("index manifest: %w", err)
+	}
+	for _, desc := range im.Manifests {
+		childRef := dst.Context().Digest(desc.Digest.String())
+		switch {
+		case desc.MediaType.IsIndex():
+			child, err := ii.ImageIndex(desc.Digest)
+			if err != nil {
+				return fmt.Errorf("child index %s: %w", desc.Digest, err)
+			}
+			if err := writeIndexLeavesFirst(childRef, child, opts...); err != nil {
+				return err
+			}
+		case desc.MediaType.IsImage():
+			child, err := ii.Image(desc.Digest)
+			if err != nil {
+				return fmt.Errorf("child image %s: %w", desc.Digest, err)
+			}
+			if err := goremote.Write(childRef, child, opts...); err != nil {
+				return fmt.Errorf("writing child image %s: %w", desc.Digest, err)
+			}
+		}
+	}
+	return goremote.WriteIndex(dst, ii, opts...)
 }
 
 func writeSignedEntitySignatures(dst name.Reference, si oci.SignedEntity, opts ...Option) error {

--- a/pkg/oci/remote/write_test.go
+++ b/pkg/oci/remote/write_test.go
@@ -17,11 +17,15 @@ package remote
 
 import (
 	"fmt"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	gcrmutate "github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/static"
@@ -540,4 +544,78 @@ func TestWriteReferrerErrorHandling(t *testing.T) {
 	if !strings.Contains(err.Error(), "remote head failed") {
 		t.Errorf("Expected error to contain 'remote head failed', got %v", err)
 	}
+}
+
+// TestWriteSignedEntity_IndexHealsMissingChild asserts a deleted index child is restored on re-push.
+func TestWriteSignedEntity_IndexHealsMissingChild(t *testing.T) {
+	imgA, err := random.Image(64, 2)
+	if err != nil {
+		t.Fatalf("random.Image: %v", err)
+	}
+	imgB, err := random.Image(64, 2)
+	if err != nil {
+		t.Fatalf("random.Image: %v", err)
+	}
+	idx := gcrmutate.AppendManifests(
+		gcrmutate.IndexMediaType(newEmptyIndex(), types.OCIImageIndex),
+		gcrmutate.IndexAddendum{Add: imgA, Descriptor: v1.Descriptor{Platform: &v1.Platform{Architecture: "amd64", OS: "linux"}}},
+		gcrmutate.IndexAddendum{Add: imgB, Descriptor: v1.Descriptor{Platform: &v1.Platform{Architecture: "arm64", OS: "linux"}}},
+	)
+	sii := signed.ImageIndex(idx)
+
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+	tagRef, err := name.ParseReference(fmt.Sprintf("%s/test/multiarch:v1", u.Host))
+	if err != nil {
+		t.Fatalf("ParseReference: %v", err)
+	}
+
+	if err := WriteSignedEntity(tagRef, sii); err != nil {
+		t.Fatalf("first WriteSignedEntity: %v", err)
+	}
+
+	idxManifest, err := sii.IndexManifest()
+	if err != nil {
+		t.Fatalf("IndexManifest: %v", err)
+	}
+	if len(idxManifest.Manifests) == 0 {
+		t.Fatal("expected at least one child manifest")
+	}
+	childDigest := idxManifest.Manifests[0].Digest
+	childRef := tagRef.Context().Digest(childDigest.String())
+	if err := remote.Delete(childRef); err != nil {
+		t.Fatalf("delete child %s: %v", childDigest, err)
+	}
+	if _, err := remote.Head(childRef); err == nil {
+		t.Fatalf("child %s still present after delete", childDigest)
+	}
+
+	if err := WriteSignedEntity(tagRef, sii); err != nil {
+		t.Fatalf("second WriteSignedEntity: %v", err)
+	}
+
+	if _, err := remote.Head(childRef); err != nil {
+		t.Fatalf("child %s not restored: %v", childDigest, err)
+	}
+}
+
+func newEmptyIndex() v1.ImageIndex {
+	return gcrmutate.IndexMediaType(localEmptyIndex{}, types.OCIImageIndex)
+}
+
+type localEmptyIndex struct{}
+
+func (localEmptyIndex) MediaType() (types.MediaType, error) { return types.OCIImageIndex, nil }
+func (localEmptyIndex) Digest() (v1.Hash, error)            { return v1.Hash{}, nil }
+func (localEmptyIndex) Size() (int64, error)                { return 0, nil }
+func (localEmptyIndex) IndexManifest() (*v1.IndexManifest, error) {
+	return &v1.IndexManifest{SchemaVersion: 2, MediaType: types.OCIImageIndex}, nil
+}
+func (localEmptyIndex) RawManifest() ([]byte, error) {
+	return []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}`), nil
+}
+func (localEmptyIndex) Image(_ v1.Hash) (v1.Image, error) { return nil, fmt.Errorf("no images") }
+func (localEmptyIndex) ImageIndex(_ v1.Hash) (v1.ImageIndex, error) {
+	return nil, fmt.Errorf("no indexes")
 }


### PR DESCRIPTION
## Summary

When `WriteSignedEntity` writes a `SignedImageIndex`, it calls `go-containerregistry`'s `remote.WriteIndex`, which short-circuits if the index manifest is already present at the destination tag. **It does not verify the children exist.** As a result, a re-push cannot heal a partially-broken index whose top-level digest is unchanged but one of its per-arch children was previously deleted (e.g. by registry garbage collection).

The fix walks the index's children first and pushes each one **by digest** (recursing into nested indexes) before publishing the index itself. `goremote.Write`/`WriteIndex` on each child still short-circuits when content is already present, so the steady-state cost is unchanged; missing children are restored.

## Code change

`pkg/oci/remote/write.go` — `WriteSignedEntity`'s `SignedImageIndex` branch now calls a new `writeIndexLeavesFirst` helper instead of `goremote.WriteIndex` directly:

```go
case oci.SignedImageIndex:
    fmt.Println("writing signed image index to", dst.Name())
-   if err := goremote.WriteIndex(dst, si, o.ROpt...); err != nil {
+   if err := writeIndexLeavesFirst(dst, si, o.ROpt...); err != nil {
        return fmt.Errorf("writing index: %w", err)
    }
```

`writeIndexLeavesFirst` walks `IndexManifest().Manifests`, pushes each leaf image by digest with `goremote.Write`, recurses into nested indexes, and finally calls `goremote.WriteIndex` to bind the tag.

## Test plan

- [x] New unit test `TestWriteSignedEntity_IndexHealsMissingChild` (in `pkg/oci/remote/write_test.go`) uses `github.com/google/go-containerregistry/pkg/registry` to spin up an in-memory OCI registry, builds a real multi-arch index, deletes one per-arch child manifest to simulate a GC pass, re-pushes, and asserts the deleted child is restored.
- [x] All pre-existing `pkg/oci/remote/` tests continue to pass.

## Why now

This surfaced via PE-8905 — a downstream registry-side bug in Stylus where `local-sync` pushes single-arch manifests and `spc-sync` later overwrites the tag with a multi-arch index. The orphaned single-arch manifest is reaped by Zot GC, and on the next K8s upgrade `containerd` 404s on its cached old digest. Centralizing the fix here in cosign avoids per-caller workarounds in Stylus, Palette, and the bundle library.

## Downstream propagation

After merge:
- bump `github.com/spectrocloud/cosign/v3` pseudo-version in `spectrocloud/bundle`'s `go.mod`, cut `v1.3.7`.
- bump `github.com/spectrocloud/bundle` in `spectrocloud/stylus`'s `go.mod` to `v1.3.7`.

Made with [Cursor](https://cursor.com)